### PR TITLE
upgrade rmagick gem

### DIFF
--- a/asciiart.gemspec
+++ b/asciiart.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('rmagick', '2.13.4')
+  gem.add_dependency('rmagick', '4.2.2')
   gem.add_dependency('rainbow', '2.0.0')
 
   gem.add_development_dependency('pry')


### PR DESCRIPTION
from version 2.13.4 to 4.2.2 to prevent `Can't install RMagick 2.15.4. Can't find MagickWand.h` while installing the Rmagick, dependency gem.

I tested the gem manually and the update didn't introduce any bugs.
I wonder if it would be worth to add test to this gem.